### PR TITLE
[Github workflow] Use upstream version from user input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,15 @@
 name: main
 
 on:
-  release:
-    types: [published]
+  push:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: >-
+          Upstream version to build container for (object SHA is also
+          accepted), defaults to latest release
+        required: false
+        type: string
 
 jobs:
   docker-publish:
@@ -14,12 +21,23 @@ jobs:
       packages: write
     # Publishing Docker images only happens when a release published out of the
     # main branch
-    if: >-
-      github.event_name == 'release'
-      && github.event.action == 'published'
-      && (github.event.release.target_commitish == 'main'
-         || github.event.release.target_commitish == 'master')
     steps:
+      - name: Determine upstream version
+        id: upstream-version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |-
+          if test -z "${{ inputs.version }}"; then
+            # Pick version from latest release
+            latest_version=$(gh release view \
+             --repo networkupstools/nut \
+             --json tagName --jq '.|to_entries[]|.value')
+          else
+            # Pick user supplied version
+            latest_version="${{ inputs.version }}"
+          fi
+          echo "value=$latest_version" >> "$GITHUB_OUTPUT"
+
       - name: Checkout the code
         uses: actions/checkout@v3
 
@@ -40,6 +58,8 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
+          build-args: |-
+            NUT_GITREF=${{ steps.upstream-version.outputs.value }}
           platforms: linux/arm/v7,linux/arm/v6,linux/arm64
           push: true
           tags:
@@ -48,4 +68,4 @@ jobs:
 
             ghcr.io/${{ github.repository_owner }}\
             /${{ github.event.repository.name }}\
-            :${{ github.event.release.tag_name }}"
+            :${{ steps.upstream-version.outputs.value }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apk add -U \
 	libusb-dev neon-dev libmodbus-dev nss-dev net-snmp-dev
 
 RUN \
-	git clone --depth=1 https://github.com/networkupstools/nut.git ${NUT_DIR} \
+	git clone https://github.com/networkupstools/nut.git ${NUT_DIR} \
 	&& cd ${NUT_DIR} \
 	&& git checkout ${NUT_GITREF} \
 	&& ./autogen.sh \
@@ -67,7 +67,7 @@ ARG NUT_GROUP
 ARG NUT_GID
 ARG NUT_RUNDIR
 
-RUN apk add -U libusb libltdl neon nss net-snmp-libs libmodbus eudev hidapi
+RUN apk -U upgrade && apk add -U libusb libltdl neon nss net-snmp-libs libmodbus eudev hidapi
 
 COPY --from=build ${DIST_DIR}/etc/ /etc/
 COPY --from=build ${DIST_DIR}/usr/lib/ /usr/lib/


### PR DESCRIPTION
* Github workflow has been adjusted to allow building the image by running the action and provide required upstream version as input (default to latest upstream release)
* Dockerfile: no longer perform shallow clone to allow building versions   other than `master`
* Dockerfile: ensure the resulting image is up-to-date re: the packages   by running `apk upgrade`