### PR TITLE
Stop UPS drivers upon exit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,8 @@ ARG NUT_GROUP
 ARG NUT_GID
 ARG NUT_RUNDIR
 
-RUN apk -U upgrade && apk add -U libusb libltdl neon nss net-snmp-libs libmodbus eudev hidapi
+# `bash` is used by `entrypoint.sh`
+RUN apk -U upgrade && apk add -U libusb libltdl neon nss net-snmp-libs libmodbus eudev hidapi bash
 
 COPY --from=build ${DIST_DIR}/etc/ /etc/
 COPY --from=build ${DIST_DIR}/usr/lib/ /usr/lib/
@@ -95,4 +96,6 @@ HEALTHCHECK CMD \
 	done; \
 	exit $rc
 
-CMD upsdrvctl start && upsd -F
+ADD --chmod=0755 entrypoint.sh /
+
+CMD ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# A full-featured shell (not `busybox` in case of Alpine or alike) is needed
+# for proper signal handling`bash`
+
+set -e
+
+function stop() {
+	echo
+ 	echo "** Stopping UPS daemon ***********"
+	echo
+	upsd -c stop
+
+	echo
+	echo "** Stopping UPS drivers **********"
+	echo
+	upsdrvctl stop
+}
+
+function start() {
+	echo
+	echo "** Starting UPS drivers **********"
+	echo
+	upsdrvctl start
+
+	echo
+	echo "** Starting UPS daemon ***********"
+	echo
+	upsd -FF
+}
+
+# Ensure UPS drivers are correctly stopped on exit, otherwise some hardware
+# could be left in an invalid state (e.g. UPS models with a cheap USB-serial
+# adapters)
+trap stop EXIT INT HUP
+
+start


### PR DESCRIPTION
* Added handling of container stop condition ensuring UPS drivers are correctly stopped on exit, otherwise some hardware could be left in an invalid state (e.g. UPS models with a cheap USB-serial adapters)